### PR TITLE
Fixes #5, a typo in the impact analysis of the cloud hardening risk.

### DIFF
--- a/risks/built-in/missing-cloud-hardening/missing-cloud-hardening-rule.go
+++ b/risks/built-in/missing-cloud-hardening/missing-cloud-hardening-rule.go
@@ -11,7 +11,7 @@ func Category() model.RiskCategory {
 		Title: "Missing Cloud Hardening",
 		Description: "Cloud components should be hardened according to the cloud vendor best practices. This affects their " +
 			"configuration, auditing, and further areas.",
-		Impact:     "If this risk is unmitigated, attackers might access cloud components in an unintended way and .",
+		Impact:     "If this risk is unmitigated, attackers might access cloud components in an unintended way.",
 		ASVS:       "V1 - Architecture, Design and Threat Modeling Requirements",
 		CheatSheet: "https://cheatsheetseries.owasp.org/cheatsheets/Attack_Surface_Analysis_Cheat_Sheet.html",
 		Action:     "Cloud Hardening",


### PR DESCRIPTION
# Overview

This fixes a simple typo in the impact analysis string of the _Missing Cloud Hardening_ risk category, resulting in a typo in the generated PDF report.

# Rollback

Revert the PR.

# Testing

I generated a new PDF report using a `threagile.yml` file that contains a cloud trust boundary, and the typo is gone.