### PR TITLE
Stored, sent and received data assets are always processed

### DIFF
--- a/main.go
+++ b/main.go
@@ -4598,6 +4598,29 @@ func parseModel(inputFilename string) {
 			}
 		}
 
+		// A target of a communication link implicitly processes all data assets that are sent to or received by that target
+		for id, techAsset := range model.ParsedModelRoot.TechnicalAssets {
+			for _, commLink := range techAsset.CommunicationLinks {
+				if commLink.TargetId == id {
+					continue
+				}
+				targetTechAsset := model.ParsedModelRoot.TechnicalAssets[commLink.TargetId]
+				dataAssetsProcessedByTarget := targetTechAsset.DataAssetsProcessed
+				for _, dataAssetSent := range commLink.DataAssetsSent {
+					if !model.Contains(dataAssetsProcessedByTarget, dataAssetSent) {
+						dataAssetsProcessedByTarget = append(dataAssetsProcessedByTarget, dataAssetSent)
+					}
+				}
+				for _, dataAssetReceived := range commLink.DataAssetsReceived {
+					if !model.Contains(dataAssetsProcessedByTarget, dataAssetReceived) {
+						dataAssetsProcessedByTarget = append(dataAssetsProcessedByTarget, dataAssetReceived)
+					}
+				}
+				targetTechAsset.DataAssetsProcessed = dataAssetsProcessedByTarget
+				model.ParsedModelRoot.TechnicalAssets[commLink.TargetId] = targetTechAsset
+			}
+		}
+
 		// Trust Boundaries ===============================================================================
 		checklistToAvoidAssetBeingModeledInMultipleTrustBoundaries := make(map[string]bool)
 		model.ParsedModelRoot.TrustBoundaries = make(map[string]model.TrustBoundary)

--- a/raa/raa/raa.go
+++ b/raa/raa/raa.go
@@ -98,12 +98,14 @@ func calculateAttackerAttractiveness(techAsset model.TechnicalAsset) float64 {
 		score += dataAsset.Integrity.AttackerAttractivenessForProcessedOrStoredData() * dataAsset.Quantity.QuantityFactor()
 		score += dataAsset.Availability.AttackerAttractivenessForProcessedOrStoredData()
 	}
+	// NOTE: Assuming all stored data is also processed, this effectively scores stored data twice
 	for _, dataAssetStored := range techAsset.DataAssetsStored {
 		dataAsset := model.ParsedModelRoot.DataAssets[dataAssetStored]
 		score += dataAsset.Confidentiality.AttackerAttractivenessForProcessedOrStoredData() * dataAsset.Quantity.QuantityFactor()
 		score += dataAsset.Integrity.AttackerAttractivenessForProcessedOrStoredData() * dataAsset.Quantity.QuantityFactor()
 		score += dataAsset.Availability.AttackerAttractivenessForProcessedOrStoredData()
 	}
+	// NOTE: To send or receive data effectively is processing that data and it's questionable if the attractiveness increases further
 	for _, dataFlow := range techAsset.CommunicationLinks {
 		for _, dataAssetSent := range dataFlow.DataAssetsSent {
 			dataAsset := model.ParsedModelRoot.DataAssets[dataAssetSent]

--- a/risks/built-in/accidental-secret-leak/accidental-secret-leak-rule.go
+++ b/risks/built-in/accidental-secret-leak/accidental-secret-leak-rule.go
@@ -23,7 +23,7 @@ func Category() model.RiskCategory {
 		Function:                   model.Operations,
 		STRIDE:                     model.InformationDisclosure,
 		DetectionLogic:             "In-scope sourcecode repositories and artifact registries.",
-		RiskAssessment:             "The risk rating depends on the sensitivity of the technical asset itself and of the data assets processed and stored.",
+		RiskAssessment:             "The risk rating depends on the sensitivity of the technical asset itself and of the data assets processed.",
 		FalsePositives:             "Usually no false positives.",
 		ModelFailurePossibleReason: false,
 		CWE:                        200,

--- a/risks/built-in/container-platform-escape/container-platform-escape-rule.go
+++ b/risks/built-in/container-platform-escape/container-platform-escape-rule.go
@@ -28,7 +28,7 @@ func Category() model.RiskCategory {
 		Function:       model.Operations,
 		STRIDE:         model.ElevationOfPrivilege,
 		DetectionLogic: "In-scope container platforms.",
-		RiskAssessment: "The risk rating depends on the sensitivity of the technical asset itself and of the data assets processed and stored.",
+		RiskAssessment: "The risk rating depends on the sensitivity of the technical asset itself and of the data assets processed.",
 		FalsePositives: "Container platforms not running parts of the target architecture can be considered " +
 			"as false positives after individual review.",
 		ModelFailurePossibleReason: false,

--- a/risks/built-in/cross-site-scripting/cross-site-scripting-rule.go
+++ b/risks/built-in/cross-site-scripting/cross-site-scripting-rule.go
@@ -21,7 +21,7 @@ func Category() model.RiskCategory {
 		Function:       model.Development,
 		STRIDE:         model.Tampering,
 		DetectionLogic: "In-scope web applications.",
-		RiskAssessment: "The risk rating depends on the sensitivity of the data processed or stored in the web application.",
+		RiskAssessment: "The risk rating depends on the sensitivity of the data processed in the web application.",
 		FalsePositives: "When the technical asset " +
 			"is not accessed via a browser-like component (i.e not by a human user initiating the request that " +
 			"gets passed through all components until it reaches the web application) this can be considered a false positive.",

--- a/risks/built-in/ldap-injection/ldap-injection-rule.go
+++ b/risks/built-in/ldap-injection/ldap-injection-rule.go
@@ -9,7 +9,7 @@ func Category() model.RiskCategory {
 		Id:    "ldap-injection",
 		Title: "LDAP-Injection",
 		Description: "When an LDAP server is accessed LDAP-Injection risks might arise. " +
-			"The risk rating depends on the sensitivity of the LDAP server itself and of the data assets processed or stored.",
+			"The risk rating depends on the sensitivity of the LDAP server itself and of the data assets processed.",
 		Impact:     "If this risk remains unmitigated, attackers might be able to modify LDAP queries and access more data from the LDAP server than allowed.",
 		ASVS:       "V5 - Validation, Sanitization and Encoding Verification Requirements",
 		CheatSheet: "https://cheatsheetseries.owasp.org/cheatsheets/LDAP_Injection_Prevention_Cheat_Sheet.html",
@@ -21,7 +21,7 @@ func Category() model.RiskCategory {
 		Function:       model.Development,
 		STRIDE:         model.Tampering,
 		DetectionLogic: "In-scope clients accessing LDAP servers via typical LDAP access protocols.",
-		RiskAssessment: "The risk rating depends on the sensitivity of the LDAP server itself and of the data assets processed or stored.",
+		RiskAssessment: "The risk rating depends on the sensitivity of the LDAP server itself and of the data assets processed.",
 		FalsePositives: "LDAP server queries by search values not consisting of parts controllable by the caller can be considered " +
 			"as false positives after individual review.",
 		ModelFailurePossibleReason: false,

--- a/risks/built-in/missing-authentication-second-factor/missing-authentication-second-factor-rule.go
+++ b/risks/built-in/missing-authentication-second-factor/missing-authentication-second-factor-rule.go
@@ -10,7 +10,7 @@ func Category() model.RiskCategory {
 		Id:    "missing-authentication-second-factor",
 		Title: "Missing Two-Factor Authentication (2FA)",
 		Description: "Technical assets (especially multi-tenant systems) should authenticate incoming requests with " +
-			"two-factor (2FA) authentication when the asset processes or stores highly sensitive data (in terms of confidentiality, integrity, and availability) and is accessed by humans.",
+			"two-factor (2FA) authentication when the asset processes highly sensitive data (in terms of confidentiality, integrity, and availability) and is accessed by humans.",
 		Impact:     "If this risk is unmitigated, attackers might be able to access or modify highly sensitive data without strong authentication.",
 		ASVS:       "V2 - Authentication Verification Requirements",
 		CheatSheet: "https://cheatsheetseries.owasp.org/cheatsheets/Multifactor_Authentication_Cheat_Sheet.html",
@@ -21,7 +21,7 @@ func Category() model.RiskCategory {
 		Function: model.BusinessSide,
 		STRIDE:   model.ElevationOfPrivilege,
 		DetectionLogic: "In-scope technical assets (except " + model.LoadBalancer.String() + ", " + model.ReverseProxy.String() + ", " + model.WAF.String() + ", " + model.IDS.String() + ", and " + model.IPS.String() + ") should authenticate incoming requests via two-factor authentication (2FA) " +
-			"when the asset processes or stores highly sensitive data (in terms of confidentiality, integrity, and availability) and is accessed by a client used by a human user.",
+			"when the asset processes highly sensitive data (in terms of confidentiality, integrity, and availability) and is accessed by a client used by a human user.",
 		RiskAssessment: model.MediumSeverity.String(),
 		FalsePositives: "Technical assets which do not process requests regarding functionality or data linked to end-users (customers) " +
 			"can be considered as false positives after individual review.",

--- a/risks/built-in/missing-authentication/missing-authentication-rule.go
+++ b/risks/built-in/missing-authentication/missing-authentication-rule.go
@@ -8,7 +8,7 @@ func Category() model.RiskCategory {
 	return model.RiskCategory{
 		Id:          "missing-authentication",
 		Title:       "Missing Authentication",
-		Description: "Technical assets (especially multi-tenant systems) should authenticate incoming requests when the asset processes or stores sensitive data. ",
+		Description: "Technical assets (especially multi-tenant systems) should authenticate incoming requests when the asset processes sensitive data. ",
 		Impact:      "If this risk is unmitigated, attackers might be able to access or modify sensitive data in an unauthenticated way.",
 		ASVS:        "V2 - Authentication Verification Requirements",
 		CheatSheet:  "https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html",
@@ -18,7 +18,7 @@ func Category() model.RiskCategory {
 		Check:    "Are recommendations from the linked cheat sheet and referenced ASVS chapter applied?",
 		Function: model.Architecture,
 		STRIDE:   model.ElevationOfPrivilege,
-		DetectionLogic: "In-scope technical assets (except " + model.LoadBalancer.String() + ", " + model.ReverseProxy.String() + ", " + model.ServiceRegistry.String() + ", " + model.WAF.String() + ", " + model.IDS.String() + ", and " + model.IPS.String() + " and in-process calls) should authenticate incoming requests when the asset processes or stores " +
+		DetectionLogic: "In-scope technical assets (except " + model.LoadBalancer.String() + ", " + model.ReverseProxy.String() + ", " + model.ServiceRegistry.String() + ", " + model.WAF.String() + ", " + model.IDS.String() + ", and " + model.IPS.String() + " and in-process calls) should authenticate incoming requests when the asset processes " +
 			"sensitive data. This is especially the case for all multi-tenant assets (there even non-sensitive ones).",
 		RiskAssessment: "The risk rating (medium or high) " +
 			"depends on the sensitivity of the data sent across the communication link. Monitoring callers are exempted from this risk.",

--- a/risks/built-in/missing-cloud-hardening/missing-cloud-hardening-rule.go
+++ b/risks/built-in/missing-cloud-hardening/missing-cloud-hardening-rule.go
@@ -28,7 +28,7 @@ func Category() model.RiskCategory {
 		Function:       model.Operations,
 		STRIDE:         model.Tampering,
 		DetectionLogic: "In-scope cloud components (either residing in cloud trust boundaries or more specifically tagged with cloud provider types).",
-		RiskAssessment: "The risk rating depends on the sensitivity of the technical asset itself and of the data assets processed and stored.",
+		RiskAssessment: "The risk rating depends on the sensitivity of the technical asset itself and of the data assets processed.",
 		FalsePositives: "Cloud components not running parts of the target architecture can be considered " +
 			"as false positives after individual review.",
 		ModelFailurePossibleReason: false,

--- a/risks/built-in/missing-file-validation/missing-file-validation-rule.go
+++ b/risks/built-in/missing-file-validation/missing-file-validation-rule.go
@@ -22,7 +22,7 @@ func Category() model.RiskCategory {
 		Function:       model.Development,
 		STRIDE:         model.Spoofing,
 		DetectionLogic: "In-scope technical assets with custom-developed code accepting file data formats.",
-		RiskAssessment: "The risk rating depends on the sensitivity of the technical asset itself and of the data assets processed and stored.",
+		RiskAssessment: "The risk rating depends on the sensitivity of the technical asset itself and of the data assets processed.",
 		FalsePositives: "Fully trusted (i.e. cryptographically signed or similar) files can be considered " +
 			"as false positives after individual review.",
 		ModelFailurePossibleReason: false,

--- a/risks/built-in/missing-hardening/missing-hardening-rule.go
+++ b/risks/built-in/missing-hardening/missing-hardening-rule.go
@@ -25,7 +25,7 @@ func Category() model.RiskCategory {
 		STRIDE:   model.Tampering,
 		DetectionLogic: "In-scope technical assets with RAA values of " + strconv.Itoa(raaLimit) + " % or higher. " +
 			"Generally for high-value targets like datastores, application servers, identity providers and ERP systems this limit is reduced to " + strconv.Itoa(raaLimitReduced) + " %",
-		RiskAssessment:             "The risk rating depends on the sensitivity of the data processed or stored in the technical asset.",
+		RiskAssessment:             "The risk rating depends on the sensitivity of the data processed in the technical asset.",
 		FalsePositives:             "Usually no false positives.",
 		ModelFailurePossibleReason: false,
 		CWE:                        16,

--- a/risks/built-in/missing-identity-store/missing-identity-store-rule.go
+++ b/risks/built-in/missing-identity-store/missing-identity-store-rule.go
@@ -21,7 +21,7 @@ func Category() model.RiskCategory {
 		STRIDE:         model.Spoofing,
 		DetectionLogic: "Models with authenticated data-flows authorized via enduser-identity missing an in-scope identity store.",
 		RiskAssessment: "The risk rating depends on the sensitivity of the enduser-identity authorized technical assets and " +
-			"their data assets processed and stored.",
+			"their data assets processed.",
 		FalsePositives: "Models only offering data/services without any real authentication need " +
 			"can be considered as false positives after individual review.",
 		ModelFailurePossibleReason: true,

--- a/risks/built-in/missing-vault/missing-vault-rule.go
+++ b/risks/built-in/missing-vault/missing-vault-rule.go
@@ -22,7 +22,7 @@ func Category() model.RiskCategory {
 		Function:       model.Architecture,
 		STRIDE:         model.InformationDisclosure,
 		DetectionLogic: "Models without a Vault (Secret Storage).",
-		RiskAssessment: "The risk rating depends on the sensitivity of the technical asset itself and of the data assets processed and stored.",
+		RiskAssessment: "The risk rating depends on the sensitivity of the technical asset itself and of the data assets processed.",
 		FalsePositives: "Models where no technical assets have any kind of sensitive config data to protect " +
 			"can be considered as false positives after individual review.",
 		ModelFailurePossibleReason: true,

--- a/risks/built-in/missing-waf/missing-waf-rule.go
+++ b/risks/built-in/missing-waf/missing-waf-rule.go
@@ -21,7 +21,7 @@ func Category() model.RiskCategory {
 		Function:       model.Operations,
 		STRIDE:         model.Tampering,
 		DetectionLogic: "In-scope web-services and/or web-applications accessed across a network trust boundary not having a Web Application Firewall (WAF) in front of them.",
-		RiskAssessment: "The risk rating depends on the sensitivity of the technical asset itself and of the data assets processed and stored.",
+		RiskAssessment: "The risk rating depends on the sensitivity of the technical asset itself and of the data assets processed.",
 		FalsePositives: "Targets only accessible via WAFs or reverse proxies containing a WAF component (like ModSecurity) can be considered " +
 			"as false positives after individual review.",
 		ModelFailurePossibleReason: false,

--- a/risks/built-in/path-traversal/path-traversal-rule.go
+++ b/risks/built-in/path-traversal/path-traversal-rule.go
@@ -9,7 +9,7 @@ func Category() model.RiskCategory {
 		Id:    "path-traversal",
 		Title: "Path-Traversal",
 		Description: "When a filesystem is accessed Path-Traversal or Local-File-Inclusion (LFI) risks might arise. " +
-			"The risk rating depends on the sensitivity of the technical asset itself and of the data assets processed or stored.",
+			"The risk rating depends on the sensitivity of the technical asset itself and of the data assets processed.",
 		Impact: "If this risk is unmitigated, attackers might be able to read sensitive files (configuration data, key/credential files, deployment files, " +
 			"business data files, etc.) from the filesystem of affected components.",
 		ASVS:       "V12 - File and Resources Verification Requirements",
@@ -23,7 +23,7 @@ func Category() model.RiskCategory {
 		Function:       model.Development,
 		STRIDE:         model.InformationDisclosure,
 		DetectionLogic: "Filesystems accessed by in-scope callers.",
-		RiskAssessment: "The risk rating depends on the sensitivity of the data stored inside the technical asset.",
+		RiskAssessment: "The risk rating depends on the sensitivity of the data processed inside the technical asset.",
 		FalsePositives: "File accesses by filenames not consisting of parts controllable by the caller can be considered " +
 			"as false positives after individual review.",
 		ModelFailurePossibleReason: false,

--- a/risks/built-in/search-query-injection/search-query-injection-rule.go
+++ b/risks/built-in/search-query-injection/search-query-injection-rule.go
@@ -24,7 +24,7 @@ func Category() model.RiskCategory {
 		Function:       model.Development,
 		STRIDE:         model.Tampering,
 		DetectionLogic: "In-scope clients accessing search engine servers via typical search access protocols.",
-		RiskAssessment: "The risk rating depends on the sensitivity of the search engine server itself and of the data assets processed or stored.",
+		RiskAssessment: "The risk rating depends on the sensitivity of the search engine server itself and of the data assets processed.",
 		FalsePositives: "Server engine queries by search values not consisting of parts controllable by the caller can be considered " +
 			"as false positives after individual review.",
 		ModelFailurePossibleReason: false,

--- a/risks/built-in/service-registry-poisoning/service-registry-poisoning-rule.go
+++ b/risks/built-in/service-registry-poisoning/service-registry-poisoning-rule.go
@@ -20,7 +20,7 @@ func Category() model.RiskCategory {
 		STRIDE:         model.Spoofing,
 		DetectionLogic: "In-scope service registries.",
 		RiskAssessment: "The risk rating depends on the sensitivity of the technical assets accessing the service registry " +
-			"as well as the data assets processed or stored.",
+			"as well as the data assets processed.",
 		FalsePositives: "Service registries not used for service discovery " +
 			"can be considered as false positives after individual review.",
 		ModelFailurePossibleReason: false,

--- a/risks/built-in/sql-nosql-injection/sql-nosql-injection-rule.go
+++ b/risks/built-in/sql-nosql-injection/sql-nosql-injection-rule.go
@@ -9,7 +9,7 @@ func Category() model.RiskCategory {
 		Id:    "sql-nosql-injection",
 		Title: "SQL/NoSQL-Injection",
 		Description: "When a database is accessed via database access protocols SQL/NoSQL-Injection risks might arise. " +
-			"The risk rating depends on the sensitivity technical asset itself and of the data assets processed or stored.",
+			"The risk rating depends on the sensitivity technical asset itself and of the data assets processed.",
 		Impact:     "If this risk is unmitigated, attackers might be able to modify SQL/NoSQL queries to steal and modify data and eventually further escalate towards a deeper system penetration via code executions.",
 		ASVS:       "V5 - Validation, Sanitization and Encoding Verification Requirements",
 		CheatSheet: "https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html",
@@ -20,7 +20,7 @@ func Category() model.RiskCategory {
 		Function:       model.Development,
 		STRIDE:         model.Tampering,
 		DetectionLogic: "Database accessed via typical database access protocols by in-scope clients.",
-		RiskAssessment: "The risk rating depends on the sensitivity of the data stored inside the database.",
+		RiskAssessment: "The risk rating depends on the sensitivity of the data processed inside the database.",
 		FalsePositives: "Database accesses by queries not consisting of parts controllable by the caller can be considered " +
 			"as false positives after individual review.",
 		ModelFailurePossibleReason: false,

--- a/risks/built-in/unencrypted-asset/unencrypted-asset-rule.go
+++ b/risks/built-in/unencrypted-asset/unencrypted-asset-rule.go
@@ -24,6 +24,7 @@ func Category() model.RiskCategory {
 			"storing data assets rated at least as " + model.Confidential.String() + " or " + model.Critical.String() + ". " +
 			"For technical assets storing data assets rated as " + model.StrictlyConfidential.String() + " or " + model.MissionCritical.String() + " the " +
 			"encryption must be of type " + model.DataWithEnduserIndividualKey.String() + ".",
+		// NOTE: the risk assesment does not only consider the CIs of the *stored* data-assets
 		RiskAssessment:             "Depending on the confidentiality rating of the stored data-assets either medium or high risk.",
 		FalsePositives:             "When all sensitive data stored within the asset is already fully encrypted on document or data level.",
 		ModelFailurePossibleReason: false,

--- a/risks/built-in/unnecessary-data-asset/unnecessary-data-asset-rule.go
+++ b/risks/built-in/unnecessary-data-asset/unnecessary-data-asset-rule.go
@@ -9,7 +9,7 @@ func Category() model.RiskCategory {
 	return model.RiskCategory{
 		Id:    "unnecessary-data-asset",
 		Title: "Unnecessary Data Asset",
-		Description: "When a data asset is not processed or stored by any data assets and also not transferred by any " +
+		Description: "When a data asset is not processed by any data assets and also not transferred by any " +
 			"communication links, this is an indicator for an unnecessary data asset (or for an incomplete model).",
 		Impact: "If this risk is unmitigated, attackers might be able to access unnecessary data assets using " +
 			"other vulnerabilities.",
@@ -20,7 +20,7 @@ func Category() model.RiskCategory {
 		Check:      "Are recommendations from the linked cheat sheet and referenced ASVS chapter applied?",
 		Function:   model.Architecture,
 		STRIDE:     model.ElevationOfPrivilege,
-		DetectionLogic: "Modelled data assets not processed or stored by any data assets and also not transferred by any " +
+		DetectionLogic: "Modelled data assets not processed by any data assets and also not transferred by any " +
 			"communication links.",
 		RiskAssessment:             model.LowSeverity.String(),
 		FalsePositives:             "Usually no false positives as this looks like an incomplete model.",

--- a/risks/built-in/unnecessary-data-transfer/unnecessary-data-transfer-rule.go
+++ b/risks/built-in/unnecessary-data-transfer/unnecessary-data-transfer-rule.go
@@ -9,15 +9,15 @@ func Category() model.RiskCategory {
 	return model.RiskCategory{
 		Id:    "unnecessary-data-transfer",
 		Title: "Unnecessary Data Transfer",
-		Description: "When a technical asset sends or receives data assets, which it neither processes or stores this is " +
+		Description: "When a technical asset sends or receives data assets, which it does not processes this is " +
 			"an indicator for unnecessarily transferred data (or for an incomplete model). When the unnecessarily " +
 			"transferred data assets are sensitive, this poses an unnecessary risk of an increased attack surface.",
 		Impact:     "If this risk is unmitigated, attackers might be able to target unnecessarily transferred data.",
 		ASVS:       "V1 - Architecture, Design and Threat Modeling Requirements",
 		CheatSheet: "https://cheatsheetseries.owasp.org/cheatsheets/Attack_Surface_Analysis_Cheat_Sheet.html",
 		Action:     "Attack Surface Reduction",
-		Mitigation: "Try to avoid sending or receiving sensitive data assets which are not required (i.e. neither " +
-			"processed or stored) by the involved technical asset.",
+		Mitigation: "Try to avoid sending or receiving sensitive data assets which are not required (i.e. not " +
+			"processed) by the involved technical asset.",
 		Check:    "Are recommendations from the linked cheat sheet and referenced ASVS chapter applied?",
 		Function: model.Architecture,
 		STRIDE:   model.ElevationOfPrivilege,
@@ -28,7 +28,7 @@ func Category() model.RiskCategory {
 			"either " + model.LowSeverity.String() + " or " + model.MediumSeverity.String() + ".",
 		FalsePositives: "Technical assets missing the model entries of either processing or storing the mentioned data assets " +
 			"can be considered as false positives (incomplete models) after individual review. These should then be addressed by " +
-			"completing the model so that all necessary data assets are processed and/or stored by the technical asset involved.",
+			"completing the model so that all necessary data assets are processed by the technical asset involved.",
 		ModelFailurePossibleReason: true,
 		CWE:                        1008,
 	}

--- a/risks/built-in/unnecessary-technical-asset/unnecessary-technical-asset-rule.go
+++ b/risks/built-in/unnecessary-technical-asset/unnecessary-technical-asset-rule.go
@@ -8,14 +8,14 @@ func Category() model.RiskCategory {
 	return model.RiskCategory{
 		Id:    "unnecessary-technical-asset",
 		Title: "Unnecessary Technical Asset",
-		Description: "When a technical asset does not process or store any data assets, this is " +
+		Description: "When a technical asset does not process any data assets, this is " +
 			"an indicator for an unnecessary technical asset (or for an incomplete model). " +
 			"This is also the case if the asset has no communication links (either outgoing or incoming).",
 		Impact:                     "If this risk is unmitigated, attackers might be able to target unnecessary technical assets.",
 		ASVS:                       "V1 - Architecture, Design and Threat Modeling Requirements",
 		CheatSheet:                 "https://cheatsheetseries.owasp.org/cheatsheets/Attack_Surface_Analysis_Cheat_Sheet.html",
 		Action:                     "Attack Surface Reduction",
-		Mitigation:                 "Try to avoid using technical assets that do not process or store anything.",
+		Mitigation:                 "Try to avoid using technical assets that do not process anything.",
 		Check:                      "Are recommendations from the linked cheat sheet and referenced ASVS chapter applied?",
 		Function:                   model.Architecture,
 		STRIDE:                     model.ElevationOfPrivilege,
@@ -35,7 +35,7 @@ func GenerateRisks() []model.Risk {
 	risks := make([]model.Risk, 0)
 	for _, id := range model.SortedTechnicalAssetIDs() {
 		technicalAsset := model.ParsedModelRoot.TechnicalAssets[id]
-		if len(technicalAsset.DataAssetsProcessed) == 0 && len(technicalAsset.DataAssetsStored) == 0 ||
+		if len(technicalAsset.DataAssetsProcessed) == 0 ||
 			(len(technicalAsset.CommunicationLinks) == 0 && len(model.IncomingTechnicalCommunicationLinksMappedByTargetId[technicalAsset.Id]) == 0) {
 			risks = append(risks, createRisk(technicalAsset))
 		}

--- a/risks/built-in/untrusted-deserialization/untrusted-deserialization-rule.go
+++ b/risks/built-in/untrusted-deserialization/untrusted-deserialization-rule.go
@@ -24,7 +24,7 @@ func Category() model.RiskCategory {
 		Function:       model.Architecture,
 		STRIDE:         model.Tampering,
 		DetectionLogic: "In-scope technical assets accepting serialization data formats (including EJB and RMI protocols).",
-		RiskAssessment: "The risk rating depends on the sensitivity of the technical asset itself and of the data assets processed and stored.",
+		RiskAssessment: "The risk rating depends on the sensitivity of the technical asset itself and of the data assets processed.",
 		FalsePositives: "Fully trusted (i.e. cryptographically signed or similar) data deserialized can be considered " +
 			"as false positives after individual review.",
 		ModelFailurePossibleReason: false,

--- a/risks/built-in/xml-external-entity/xml-external-entity-rule.go
+++ b/risks/built-in/xml-external-entity/xml-external-entity-rule.go
@@ -21,7 +21,7 @@ func Category() model.RiskCategory {
 		Function:       model.Development,
 		STRIDE:         model.InformationDisclosure,
 		DetectionLogic: "In-scope technical assets accepting XML data formats.",
-		RiskAssessment: "The risk rating depends on the sensitivity of the technical asset itself and of the data assets processed and stored. " +
+		RiskAssessment: "The risk rating depends on the sensitivity of the technical asset itself and of the data assets processed. " +
 			"Also for cloud-based environments the exploitation impact is at least medium, as cloud backend services can be attacked via SSRF (and XXE vulnerabilities are often also SSRF vulnerabilities).",
 		FalsePositives: "Fully trusted (i.e. cryptographically signed or similar) XML data can be considered " +
 			"as false positives after individual review.",

--- a/support/schema.json
+++ b/support/schema.json
@@ -470,7 +470,7 @@
             "type": "boolean"
           },
           "data_assets_processed": {
-            "description": "Data assets processed",
+            "description": "Data assets processed; all data assets stored or send or received via a communication link are implicitly also processed",
             "type": [
               "array",
               "null"
@@ -680,9 +680,7 @@
                 "vpn",
                 "ip_filtered",
                 "readonly",
-                "usage",
-                "data_assets_sent",
-                "data_assets_received"
+                "usage"
               ]
             }
           },
@@ -705,8 +703,6 @@
             "multi_tenant",
             "redundant",
             "custom_developed_parts",
-            "data_assets_processed",
-            "data_assets_stored",
             "data_formats_accepted",
             "communication_links"
           ]

--- a/support/schema.json
+++ b/support/schema.json
@@ -470,7 +470,7 @@
             "type": "boolean"
           },
           "data_assets_processed": {
-            "description": "Data assets processed; all data assets stored or send or received via a communication link are implicitly also processed",
+            "description": "Data assets processed; all data assets stored or sent or received via a communication link (be it as a source or a target) are implicitly also processed and do not need to be listed here.",
             "type": [
               "array",
               "null"


### PR DESCRIPTION
Hi,

thank you very much for your great work on this project, I hope it is still active and open for pull requests.

### Rationale
Whenever data assets are stored, sent or received by a technical asset they are also processed in some way by that technical asset. This leads to tight coupling of `data_assets_processed` with `data_assets_stored`, `data_assets_sent` and `data_assets_received` (relating to both, outgoing and incoming communication links). IMHO `data_assets_processed` is of almost no practical use, when a data asset processed is not stored and not transferred somewhere.

### Proposal
Infer `data_assets_processed` based on data assets stored and data assets used in outgoing and incoming communication links and do not require `data_assets_processed` to be set and continuously maintained.

As a stored data asset always implies a processed data asset some of the code became redundant and was removed.

I look forward to your feedback!