### PR TITLE
Infer CIA ratings of tech assets

### DIFF
--- a/main.go
+++ b/main.go
@@ -4296,6 +4296,9 @@ func parseModel(inputFilename string) {
 				confidentiality = model.Confidential
 			case model.StrictlyConfidential.String():
 				confidentiality = model.StrictlyConfidential
+			case "":
+				// Temporary placeholder, will later be set to `HighestConfidentiality()`
+				confidentiality = -1
 			default:
 				panic(errors.New("unknown 'confidentiality' value of technical asset '" + title + "': " + fmt.Sprintf("%v", asset.Confidentiality)))
 			}
@@ -4312,6 +4315,9 @@ func parseModel(inputFilename string) {
 				integrity = model.Critical
 			case model.MissionCritical.String():
 				integrity = model.MissionCritical
+			case "":
+				// Temporary placeholder, will later be set to `HighestIntegrity()`
+				integrity = -1
 			default:
 				panic(errors.New("unknown 'integrity' value of technical asset '" + title + "': " + fmt.Sprintf("%v", asset.Integrity)))
 			}
@@ -4328,6 +4334,9 @@ func parseModel(inputFilename string) {
 				availability = model.Critical
 			case model.MissionCritical.String():
 				availability = model.MissionCritical
+			case "":
+				// Temporary placeholder, will later be set to `HighestAvailability()`
+				availability = -1
 			default:
 				panic(errors.New("unknown 'availability' value of technical asset '" + title + "': " + fmt.Sprintf("%v", asset.Availability)))
 			}
@@ -4584,6 +4593,20 @@ func parseModel(inputFilename string) {
 				CommunicationLinks:      communicationLinks,
 				DiagramTweakOrder:       asset.Diagram_tweak_order,
 			}
+		}
+
+		// If CIA was not set (i.e. equals -1) it is implicitly set to its highest calculated value
+		for id, techAsset := range model.ParsedModelRoot.TechnicalAssets {
+			if techAsset.Confidentiality < 0 {
+				techAsset.Confidentiality = techAsset.HighestConfidentiality()
+			}
+			if techAsset.Integrity < 0 {
+				techAsset.Integrity = techAsset.HighestIntegrity()
+			}
+			if techAsset.Availability < 0 {
+				techAsset.Availability = techAsset.HighestAvailability()
+			}
+			model.ParsedModelRoot.TechnicalAssets[id] = techAsset
 		}
 
 		// Trust Boundaries ===============================================================================

--- a/main.go
+++ b/main.go
@@ -4599,12 +4599,24 @@ func parseModel(inputFilename string) {
 		for id, techAsset := range model.ParsedModelRoot.TechnicalAssets {
 			if techAsset.Confidentiality < 0 {
 				techAsset.Confidentiality = techAsset.HighestConfidentiality()
+				if techAsset.Confidentiality < 0 {
+					// no data asset is processed or stored, thus falling back to the lowest level
+					techAsset.Confidentiality = model.Public
+				}
 			}
 			if techAsset.Integrity < 0 {
 				techAsset.Integrity = techAsset.HighestIntegrity()
+				if techAsset.Integrity < 0 {
+					// no data asset is processed or stored, thus falling back to the lowest level
+					techAsset.Integrity = model.Archive
+				}
 			}
 			if techAsset.Availability < 0 {
 				techAsset.Availability = techAsset.HighestAvailability()
+				if techAsset.Availability < 0 {
+					// no data asset is processed or stored, thus falling back to the lowest level
+					techAsset.Availability = model.Archive
+				}
 			}
 			model.ParsedModelRoot.TechnicalAssets[id] = techAsset
 		}

--- a/support/schema.json
+++ b/support/schema.json
@@ -418,7 +418,7 @@
             ]
           },
           "confidentiality": {
-            "description": "Confidentiality",
+            "description": "Confidentiality; defaults to the highest confidentiality value of all processed data asset",
             "type": "string",
             "enum": [
               "public",
@@ -429,7 +429,7 @@
             ]
           },
           "integrity": {
-            "description": "Integrity",
+            "description": "Integrity; defaults to the highest integrity value of all processed data asset",
             "type": "string",
             "enum": [
               "archive",
@@ -440,7 +440,7 @@
             ]
           },
           "availability": {
-            "description": "Availability",
+            "description": "Availability; defaults to the highest availability value of all processed data asset",
             "type": "string",
             "enum": [
               "archive",
@@ -699,9 +699,6 @@
             "machine",
             "encryption",
             "owner",
-            "confidentiality",
-            "integrity",
-            "availability",
             "multi_tenant",
             "redundant",
             "custom_developed_parts",


### PR DESCRIPTION
Hi,

just another pull request from my side.

### Rationale

Confidentiality, Integrity and Availability (CIA) of a tech asset may be inferred from the data that tech asset processes.

### Proposal

Infer CIA based on the data assets processed. If CIA can not be inferred, i.e. if no data asset is processed (probably this rarely happens in practice), fall back to the lowest possible level. If a value for CIA is set, it takes precedence.