### PR TITLE
fix: required fields on wrong level in schema

### DIFF
--- a/support/schema.json
+++ b/support/schema.json
@@ -685,32 +685,32 @@
                 "data_assets_received"
               ]
             }
-          },
-          "required": [
-            "id",
-            "description",
-            "type",
-            "usage",
-            "used_as_client_by_human",
-            "out_of_scope",
-            "size",
-            "technology",
-            "internet",
-            "machine",
-            "encryption",
-            "owner",
-            "confidentiality",
-            "integrity",
-            "availability",
-            "multi_tenant",
-            "redundant",
-            "custom_developed_parts",
-            "data_assets_processed",
-            "data_assets_stored",
-            "data_formats_accepted",
-            "communication_links"
-          ]
-        }
+          }
+        },
+        "required": [
+          "id",
+          "description",
+          "type",
+          "usage",
+          "used_as_client_by_human",
+          "out_of_scope",
+          "size",
+          "technology",
+          "internet",
+          "machine",
+          "encryption",
+          "owner",
+          "confidentiality",
+          "integrity",
+          "availability",
+          "multi_tenant",
+          "redundant",
+          "custom_developed_parts",
+          "data_assets_processed",
+          "data_assets_stored",
+          "data_formats_accepted",
+          "communication_links"
+        ]
       }
     },
     "trust_boundaries": {


### PR DESCRIPTION
Hello,

when using the provided `schema.json` then my IDE (IntelliJ IDEA) doesn't show some required fields as missing but the threagile CLI does when creating the report. The IDE also shows that the `schema.json` itself is invalid.

This commit should fix this. Basically it just moves the `required` property up one level.

Best regards.
