### PR TITLE
Fix anchore scan for pull requests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,7 @@
 **/.gitignore
 **/.DS_Store
 **/*.tmp
+.github
+.dockerignore
+Dockerfile
+Dockerfile.*

--- a/.github/workflows/anchore-analysis.yml
+++ b/.github/workflows/anchore-analysis.yml
@@ -15,7 +15,7 @@ on:
     # The branches below must be a subset of the branches above
     branches: [master]
   schedule:
-    - cron: "0 0 1 * *"
+    - cron: '0 0 1 * *'
 
 jobs:
   Anchore-Build-Scan:

--- a/.github/workflows/anchore-analysis.yml
+++ b/.github/workflows/anchore-analysis.yml
@@ -15,23 +15,30 @@ on:
     # The branches below must be a subset of the branches above
     branches: [master]
   schedule:
-    - cron: '0 0 1 * *'
+    - cron: "0 0 1 * *"
 
 jobs:
   Anchore-Build-Scan:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout the code
-      uses: actions/checkout@v4
-    - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag localbuild/testimage:latest      
-    - name: Run the local Anchore scan action itself with GitHub Advanced Security code scanning integration enabled
-      uses: anchore/scan-action@v3
-      with:
-        image-reference: "localbuild/testimage:latest"
-        dockerfile-path: "Dockerfile"
-        acs-report-enable: true
-    - name: Upload Anchore Scan Report
-      uses: github/codeql-action/upload-sarif@v1
-      with:
-        sarif_file: results.sarif
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build the Docker image
+        uses: docker/build-push-action@v5
+        with:
+          tags: localbuild/threagile:latest
+          file: Dockerfile.local
+          push: false
+          load: true
+
+      - name: Scan image
+        uses: anchore/scan-action@v3
+        with:
+          image: "localbuild/threagile:latest"
+          fail-build: false
+
+      - name: Upload Anchore Scan Report
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: results.sarif

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -39,7 +39,6 @@ RUN : \
 ######
 ## Stage 2: Make final small image
 ######
-
 FROM docker.io/library/alpine:latest
 
 # Label used in other scripts to filter
@@ -51,6 +50,14 @@ RUN apk add --no-cache \
     ttf-freefont
 
 WORKDIR /app
+
+# Add non-privileged user for running threagile
+RUN adduser \
+    --disabled-password \
+    --gecos "" \
+    --home "$(pwd)" \
+    --no-create-home \
+    threagile
 
 # Copy necessary files from build image
 COPY --from=build \
@@ -69,11 +76,11 @@ COPY --from=build \
 
 RUN : \
     && mkdir /data \
-    && chown -R 1000:1000 /app /data
+    && chown -R threagile:threagile /app /data
 
-USER 1000:1000
+USER threagile
 
-ENV PATH=/app:"{$PATH}" \
+ENV PATH="${PATH}:/app" \
     GIN_MODE=release
 
 ENTRYPOINT ["/app/threagile"]

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -3,30 +3,34 @@
 ######
 ## Stage 1: Build application with Go's build tools
 ######
-FROM docker.io/library/golang:alpine as builder
+FROM docker.io/library/golang:alpine as build
 
+# Add build dependencies (gcc, c stdlib)
 RUN apk add --no-cache build-base
 
 WORKDIR /app
 
+# Cache build dependencies
 COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
 
+# Set build-time variables
 ARG GOOS=linux
 
 RUN : \
     && go version \
     && go test ./...
 
+# Build plugins and threagile
 RUN : \
     && go build -a -trimpath -ldflags="-s -w -X main.buildTimestamp=$(date '+%Y%m%d%H%M%S')" -buildmode=plugin -o raa.so raa/raa/raa.go \
     && go build -a -trimpath -ldflags="-s -w -X main.buildTimestamp=$(date '+%Y%m%d%H%M%S')" -buildmode=plugin -o dummy.so raa/dummy/dummy.go \
     && go build -a -trimpath -ldflags="-s -w -X main.buildTimestamp=$(date '+%Y%m%d%H%M%S')" -buildmode=plugin -o demo-rule.so risks/custom/demo/demo-rule.go \
     && go build -a -trimpath -ldflags="-s -w -X main.buildTimestamp=$(date '+%Y%m%d%H%M%S')" -o threagile
 
-# NOTE: copy files with final name to send to final image
+# Copy files in build image to simplify copy instruction
 RUN : \
     && cp /app/demo/example/threagile.yaml /app/demo/example/threagile-example-model.yaml \
     && cp /app/demo/stub/threagile.yaml /app/demo/stub/threagile-stub-model.yaml
@@ -37,6 +41,8 @@ RUN : \
 ######
 
 FROM docker.io/library/alpine:latest
+
+# Label used in other scripts to filter
 LABEL type="threagile"
 
 RUN apk add --no-cache \
@@ -46,7 +52,8 @@ RUN apk add --no-cache \
 
 WORKDIR /app
 
-COPY --from=builder \
+# Copy necessary files from build image
+COPY --from=build \
     /app/*.so \
     /app/demo/example/threagile-example-model.yaml \
     /app/demo/stub/threagile-stub-model.yaml \
@@ -56,7 +63,7 @@ COPY --from=builder \
     /app/threagile \
     /app/
 
-COPY --from=builder \
+COPY --from=build \
     /app/server \
     /app/server
 

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -61,7 +61,9 @@ RUN adduser \
 
 # Copy necessary files from build image
 COPY --from=build \
-    /app/*.so \
+    /app/raa.so \
+    /app/dummy.so \
+    /app/demo-rule.so \
     /app/demo/example/threagile-example-model.yaml \
     /app/demo/stub/threagile-stub-model.yaml \
     /app/LICENSE.txt \

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,79 +1,73 @@
 # Used for local manual test builds
 
 ######
-## Stage 1: Clone the Git repository
+## Stage 1: Build application with Go's build tools
 ######
-FROM alpine/git as clone
+FROM docker.io/library/golang:alpine as builder
+
+RUN apk add --no-cache build-base
+
 WORKDIR /app
-#RUN git clone https://github.com/threagile/threagile.git
-COPY . /app/threagile
 
+COPY go.mod go.sum ./
+RUN go mod download
 
+COPY . .
+
+ARG GOOS=linux
+
+RUN : \
+    && go version \
+    && go test ./...
+
+RUN : \
+    && go build -a -trimpath -ldflags="-s -w -X main.buildTimestamp=$(date '+%Y%m%d%H%M%S')" -buildmode=plugin -o raa.so raa/raa/raa.go \
+    && go build -a -trimpath -ldflags="-s -w -X main.buildTimestamp=$(date '+%Y%m%d%H%M%S')" -buildmode=plugin -o dummy.so raa/dummy/dummy.go \
+    && go build -a -trimpath -ldflags="-s -w -X main.buildTimestamp=$(date '+%Y%m%d%H%M%S')" -buildmode=plugin -o demo-rule.so risks/custom/demo/demo-rule.go \
+    && go build -a -trimpath -ldflags="-s -w -X main.buildTimestamp=$(date '+%Y%m%d%H%M%S')" -o threagile
+
+# NOTE: copy files with final name to send to final image
+RUN : \
+    && cp /app/demo/example/threagile.yaml /app/demo/example/threagile-example-model.yaml \
+    && cp /app/demo/stub/threagile.yaml /app/demo/stub/threagile-stub-model.yaml
 
 
 ######
-## Stage 2: Build application with Go's build tools
+## Stage 2: Make final small image
 ######
-FROM golang as build
-ENV GO111MODULE=on
-# https://stackoverflow.com/questions/36279253/go-compiled-binary-wont-run-in-an-alpine-docker-container-on-ubuntu-host
-#ENV CGO_ENABLED=0 # cannot be set as otherwise plugins don't run
-WORKDIR /app
-COPY --from=clone /app/threagile /app
-RUN go version
-RUN go test ./...
-RUN GOOS=linux go build -a -trimpath -ldflags="-s -w -X main.buildTimestamp=$(date '+%Y%m%d%H%M%S')" -buildmode=plugin -o raa.so raa/raa/raa.go
-RUN GOOS=linux go build -a -trimpath -ldflags="-s -w -X main.buildTimestamp=$(date '+%Y%m%d%H%M%S')" -buildmode=plugin -o dummy.so raa/dummy/dummy.go
-RUN GOOS=linux go build -a -trimpath -ldflags="-s -w -X main.buildTimestamp=$(date '+%Y%m%d%H%M%S')" -buildmode=plugin -o demo-rule.so risks/custom/demo/demo-rule.go
-RUN GOOS=linux go build -a -trimpath -ldflags="-s -w -X main.buildTimestamp=$(date '+%Y%m%d%H%M%S')" -o threagile
-# add the -race parameter to go build call in order to instrument with race condition detector: https://blog.golang.org/race-detector
 
-
-
-
-######
-## Stage 3: Make final small image
-######
-FROM alpine
-
-# label used in other scripts to filter
+FROM docker.io/library/alpine:latest
 LABEL type="threagile"
 
-# add certificates
-RUN apk add ca-certificates
-# add graphviz, fonts
-RUN apk add --update --no-cache graphviz ttf-freefont
-# https://stackoverflow.com/questions/66963068/docker-alpine-executable-binary-not-found-even-if-in-path
-RUN apk add libc6-compat
-# https://stackoverflow.com/questions/34729748/installed-go-binary-not-found-in-path-on-alpine-linux-docker
-# RUN mkdir -p /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
-# clean apk cache
-RUN rm -rf /var/cache/apk/*
+RUN apk add --no-cache \
+    ca-certificates \
+    graphviz \
+    ttf-freefont
 
 WORKDIR /app
 
-COPY --from=build /app/threagile /app/threagile
-COPY --from=build /app/raa.so /app/raa.so
-COPY --from=build /app/dummy.so /app/dummy.so
-COPY --from=build /app/demo-rule.so /app/demo-rule.so
-COPY --from=build /app/LICENSE.txt /app/LICENSE.txt
-COPY --from=build /app/report/template/background.pdf /app/background.pdf
-COPY --from=build /app/support/openapi.yaml /app/openapi.yaml
-COPY --from=build /app/support/schema.json /app/schema.json
-COPY --from=build /app/support/live-templates.txt /app/live-templates.txt
-COPY --from=build /app/support/render-data-asset-diagram.sh /app/render-data-asset-diagram.sh
-COPY --from=build /app/support/render-data-flow-diagram.sh /app/render-data-flow-diagram.sh
-COPY --from=build /app/server /app/server
-COPY --from=build /app/demo/example/threagile.yaml /app/threagile-example-model.yaml
-COPY --from=build /app/demo/stub/threagile.yaml /app/threagile-stub-model.yaml
+COPY --from=builder \
+    /app/*.so \
+    /app/demo/example/threagile-example-model.yaml \
+    /app/demo/stub/threagile-stub-model.yaml \
+    /app/LICENSE.txt \
+    /app/report/template/background.pdf \
+    /app/support/ \
+    /app/threagile \
+    /app/
 
-RUN mkdir /data
+COPY --from=builder \
+    /app/server \
+    /app/server
 
-RUN chown -R 1000:1000 /app /data
+RUN : \
+    && mkdir /data \
+    && chown -R 1000:1000 /app /data
+
 USER 1000:1000
 
-ENV PATH=/app:$PATH
-ENV GIN_MODE=release
+ENV PATH=/app:"{$PATH}" \
+    GIN_MODE=release
 
 ENTRYPOINT ["/app/threagile"]
 CMD ["-help"]


### PR DESCRIPTION
Currently, running the anchore scan on pull requests does not scan the changed files from the pull request. Instead it uses the `Dockerfile`, where the main repo https://github.com/Threagile/threagile.git is being cloned. 

In order to properly scan the pull request I refactored `Dockerfile.local` and used it in the github action. Now the actual changes from the pull request are considered in the scan.

One possibly controversial change is the option `fail-build: false` in `.github/workflows/anchore-analysis.yml`. This allows the build to succeed while still reporting the found vulnerabilities in the Security tab.
For example, currently there are vulnerabilities in alpine linux that do not have a  fix available. Most of the time this cannot be avoided.

Generally I would recommend only having one Dockerfile and removing the docker-build-*.sh files or moving them to a non-default branch. If someone wants to build from the master branch, simply using `git stash --include-untracked` and `git checkout master` should be enough to build the main container file.

I would recommend versioning and automatically pushing the image to Dockerhub instead though. If the maintainers are interested in this I could help setting that up.


