### PR TITLE
add an error message if a technical asset is missing which is used inside a communication link list, instead of crash

### DIFF
--- a/pkg/model/parse.go
+++ b/pkg/model/parse.go
@@ -394,6 +394,9 @@ func ParseModel(config *common.Config, modelInput *input.Model, builtinRiskRules
 				continue
 			}
 			targetTechAsset := parsedModel.TechnicalAssets[commLink.TargetId]
+			if targetTechAsset == nil {
+				return nil, fmt.Errorf("missing target technical asset %q for communication link: %q", commLink.TargetId, commLink.Title)
+			}
 			dataAssetsProcessedByTarget := targetTechAsset.DataAssetsProcessed
 			for _, dataAssetSent := range commLink.DataAssetsSent {
 				if !contains(dataAssetsProcessedByTarget, dataAssetSent) {


### PR DESCRIPTION
During the creation of a large thread model I might have forgotten to define something, which led to:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0xd8 pc=0x6f3278]

goroutine 1 [running]:
github.com/threagile/threagile/pkg/model.ParseModel(0xc0000c5188, 0xc0000bb400, 0xc000282270, 0xc000221920)
        /app/pkg/model/parse.go:397 +0x54d8
github.com/threagile/threagile/pkg/model.ReadAndAnalyzeModel(0xc0000c5188, {0xf45368, 0xc0005a8456})
        /app/pkg/model/read.go:41 +0x3a5
github.com/threagile/threagile/internal/threagile.(*Threagile).initAnalyze.func1(0xc0004b2d00?, {0xda0c41?, 0x4?, 0xda0c45?})
        /app/internal/threagile/analyze.go:21 +0xec
github.com/spf13/cobra.(*Command).execute(0xc0000ce608, {0xc000533340, 0x4, 0x4})
        /go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:983 +0xaca
github.com/spf13/cobra.(*Command).ExecuteC(0xc0000ce308)
        /go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
        /go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039
github.com/threagile/threagile/internal/threagile.(*Threagile).Execute(0xc00009cf00)
        /app/internal/threagile/threagile.go:16 +0x25
main.main()
        /app/cmd/threagile/main.go:12 +0x32
```
After the fix it reports:
```
failed to read and analyze model: unable to parse model yaml: missing target technical asset "missing-asset-id" for communication link: "Missing Asset Comm Name"
```