### PR TITLE
superfluous error handling removed

### DIFF
--- a/pkg/model/parse.go
+++ b/pkg/model/parse.go
@@ -286,9 +286,6 @@ func ParseModel(config *common.Config, modelInput *input.Model, builtinRiskRules
 				}
 
 				dataFlowTitle := fmt.Sprintf("%v", commLinkTitle)
-				if err != nil {
-					return nil, err
-				}
 				commLinkId, err := createDataFlowId(id, dataFlowTitle)
 				if err != nil {
 					return nil, err

--- a/pkg/model/parse.go
+++ b/pkg/model/parse.go
@@ -186,9 +186,6 @@ func ParseModel(config *common.Config, modelInput *input.Model, builtinRiskRules
 			technicalAssetTechnologies = append(technicalAssetTechnologies, technicalAssetTechnology)
 		}
 
-		if err != nil {
-			return nil, fmt.Errorf("unknown 'technology' value of technical asset %q: %v", title, asset.Technology)
-		}
 		encryption, err := types.ParseEncryptionStyle(asset.Encryption)
 		if err != nil {
 			return nil, fmt.Errorf("unknown 'encryption' value of technical asset %q: %v", title, asset.Encryption)

--- a/pkg/script/script.go
+++ b/pkg/script/script.go
@@ -298,7 +298,7 @@ func (what *Script) generateRisk(outerScope *common.Scope, techAsset any) (*type
 		}
 
 		newValue, errorEvalLiteral, evalError := expression.EvalAny(scope)
-		if parseError != nil {
+		if evalError != nil {
 			return nil, errorEvalLiteral, fmt.Errorf("failed to eval field value: %v", evalError)
 		}
 


### PR DESCRIPTION
The err variable can not have changed, because the previous function, does not give back an error variable