### PR TITLE
double import

### DIFF
--- a/pkg/security/types/technology-map.go
+++ b/pkg/security/types/technology-map.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"embed"
-	_ "embed"
 	"fmt"
 	"os"
 	"path/filepath"


### PR DESCRIPTION
if we don't use embed explicitly we need the implicit import, but since we are using it explicitly (embed.FS) we need to explicitly import it. Importing it both ways serves no purpose.