### PR TITLE
add use-external-data-flow-diagram argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ The easiest way to execute Threagile on the commandline is via its Docker contai
         	generate data asset diagram (default true)
       -generate-data-flow-diagram
         	generate data-flow diagram (default true)
+      -use-external-data-flow-diagram
+          use a custom data flow diagram instead of the generated onde (default "")
       -generate-report-pdf
         	generate report pdf, including diagrams (default true)
       -generate-risks-excel

--- a/internal/threagile/flags.go
+++ b/internal/threagile/flags.go
@@ -30,6 +30,7 @@ const (
 
 	generateDataFlowDiagramFlagName     = "generate-data-flow-diagram"
 	generateDataAssetDiagramFlagName    = "generate-data-asset-diagram"
+	useExternalDataFlowDiagramFlagName  = "use-external-data-flow-diagram"
 	generateRisksJSONFlagName           = "generate-risks-json"
 	generateTechnicalAssetsJSONFlagName = "generate-technical-assets-json"
 	generateStatsJSONFlagName           = "generate-stats-json"
@@ -57,6 +58,7 @@ type Flags struct {
 
 	generateDataFlowDiagramFlag     bool
 	generateDataAssetDiagramFlag    bool
+	useExternalDataFlowDiagramFlag  string
 	generateRisksJSONFlag           bool
 	generateTechnicalAssetsJSONFlag bool
 	generateStatsJSONFlag           bool

--- a/internal/threagile/root.go
+++ b/internal/threagile/root.go
@@ -74,6 +74,7 @@ func (what *Threagile) initRoot() *Threagile {
 
 	what.rootCmd.PersistentFlags().BoolVar(&what.flags.generateDataFlowDiagramFlag, generateDataFlowDiagramFlagName, true, "generate data flow diagram")
 	what.rootCmd.PersistentFlags().BoolVar(&what.flags.generateDataAssetDiagramFlag, generateDataAssetDiagramFlagName, true, "generate data asset diagram")
+	what.rootCmd.PersistentFlags().StringVar(&what.flags.useExternalDataFlowDiagramFlag, useExternalDataFlowDiagramFlagName, "", "external data flow diagram (png)")
 	what.rootCmd.PersistentFlags().BoolVar(&what.flags.generateRisksJSONFlag, generateRisksJSONFlagName, true, "generate risks json")
 	what.rootCmd.PersistentFlags().BoolVar(&what.flags.generateTechnicalAssetsJSONFlag, generateTechnicalAssetsJSONFlagName, true, "generate technical assets json")
 	what.rootCmd.PersistentFlags().BoolVar(&what.flags.generateStatsJSONFlag, generateStatsJSONFlagName, true, "generate stats json")
@@ -208,6 +209,7 @@ func (what *Threagile) readCommands() *report.GenerateCommands {
 	commands := new(report.GenerateCommands).Defaults()
 	commands.DataFlowDiagram = what.flags.generateDataFlowDiagramFlag
 	commands.DataAssetDiagram = what.flags.generateDataAssetDiagramFlag
+	commands.UseExternalDataFlowDiagram = what.flags.useExternalDataFlowDiagramFlag
 	commands.RisksJSON = what.flags.generateRisksJSONFlag
 	commands.StatsJSON = what.flags.generateStatsJSONFlag
 	commands.TechnicalAssetsJSON = what.flags.generateTechnicalAssetsJSONFlag


### PR DESCRIPTION
 add `use-external-data-flow-diagram` to replace the generated diagram with a custom one. 

If one has a larger threat model the graphviz version is quite ugly.