### PR TITLE
fix docker build

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -40,8 +40,8 @@ FROM alpine:latest as finalize
 LABEL type="threagile"
 
 # update vulnerable packages
-RUN apk add libcrypto3=3.3.1-r0
-RUN apk add libssl3=3.3.1-r0
+RUN apk add libcrypto3=3.3.1-r3
+RUN apk add libssl3=3.3.1-r3
 
 # add certificates, graphviz, fonts
 RUN apk add --update --no-cache ca-certificates


### PR DESCRIPTION
No clue why those "vulnerable packages" where pinned but r0 is gone so i updated to r3
