### PR TITLE
JSON schema: require one of 'technology' or 'technologies'

### DIFF
--- a/support/schema.json
+++ b/support/schema.json
@@ -832,6 +832,14 @@
             }
           }
         },
+        "allOf": [
+          {
+            "anyOf": [
+              { "required": ["technology"] },
+              { "required": ["technologies"] }
+            ]
+          }
+        ],
         "required": [
           "id",
           "description",
@@ -840,7 +848,6 @@
           "used_as_client_by_human",
           "out_of_scope",
           "size",
-          "technology",
           "internet",
           "machine",
           "encryption",


### PR DESCRIPTION
Fixes #145

Previously the schema mandated 'technology', but that's deprecated by 'technologies', so only one of the two should be required.