### PR TITLE
Fix JSON schema's $schema reference

### DIFF
--- a/support/schema.json
+++ b/support/schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://threagile.io/schema#",
+  "$schema": "https://json-schema.org/draft-07/schema#",
   "id": "https://threagile.io/schema.json",
   "title": "Threagile",
   "description": "Agile Threat Modeling",


### PR DESCRIPTION
Fixes #147

JSON schema files should reference the JSON Schema specification rather than themselves.