### PR TITLE
Build and publish multi-arch (amd64 + arm64) Docker images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,56 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    branches: [master]
+    tags: ['v*']
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Push only on master/tags, not on pull requests (forks have no write access).
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push multi-arch image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.local
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,19 +14,25 @@ RUN git clone https://github.com/threagile/threagile.git
 ######
 ## Stage 2: Build application with Go's build tools
 ######
-FROM golang AS build
+# Build on the native platform and cross-compile to the requested target platform.
+# BuildKit injects BUILDPLATFORM/TARGETOS/TARGETARCH automatically (multi-arch builds).
+FROM --platform=$BUILDPLATFORM golang AS build
 WORKDIR /app
 
-ENV GO111MODULE=on
-
-# https://stackoverflow.com/questions/36279253/go-compiled-binary-wont-run-in-an-alpine-docker-container-on-ubuntu-host
-#ENV CGO_ENABLED=0 # cannot be set as otherwise plugins don't run
+ARG TARGETOS
+ARG TARGETARCH
+# CGO is disabled so binaries are static and can be cross-compiled cleanly.
+# Threagile uses no cgo and no Go plugins (custom risk rules are external executables
+# invoked via os/exec), so disabling CGO is safe.
+ENV GO111MODULE=on CGO_ENABLED=0
 COPY --from=clone /app/threagile /app
 
 RUN go version
-RUN go test ./...
-RUN GOOS=linux go build -ldflags="-X main.buildTimestamp=$(date '+%Y%m%d%H%M%S')" -o risk_demo_rule cmd/risk_demo/main.go
-RUN GOOS=linux go build -ldflags="-X main.buildTimestamp=$(date '+%Y%m%d%H%M%S')" -o threagile
+# Tests can only be executed for the native build architecture; cross-compiled test
+# binaries cannot run on the builder. Run them only when not cross-compiling.
+RUN if [ "$TARGETARCH" = "$(go env GOHOSTARCH)" ]; then go test ./...; else echo "skip tests (cross-compile to $TARGETARCH)"; fi
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-X main.buildTimestamp=$(date '+%Y%m%d%H%M%S')" -o risk_demo_rule cmd/risk_demo/main.go
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-X main.buildTimestamp=$(date '+%Y%m%d%H%M%S')" -o threagile
 # add the -race parameter to go build call in order to instrument with race condition detector: https://blog.golang.org/race-detector
 # NOTE: copy files with final name to send to final build
 RUN cp /app/demo/example/threagile.yaml /app/demo/example/threagile-example-model.yaml

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -3,24 +3,31 @@
 ######
 ## Stage 1: Build application with Go's build tools
 ######
-FROM docker.io/library/golang:alpine AS build
+# Build on the native platform and cross-compile to the requested target platform.
+# BuildKit injects BUILDPLATFORM/TARGETOS/TARGETARCH automatically (multi-arch builds).
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:alpine AS build
 
 COPY . /app
 WORKDIR /app
 
-ARG GOOS=linux
-ENV GO111MODULE=on
+ARG TARGETOS
+ARG TARGETARCH
+# CGO is disabled so binaries are static and can be cross-compiled cleanly.
+# Threagile uses no cgo and no Go plugins (custom risk rules are external executables
+# invoked via os/exec), so disabling CGO is safe.
+ENV GO111MODULE=on CGO_ENABLED=0
 
 # download dependencies
 RUN go mod download
 
-# Set build-time variables
 RUN go version
-RUN go test ./...
+# Tests can only be executed for the native build architecture; cross-compiled test
+# binaries cannot run on the builder. Run them only when not cross-compiling.
+RUN if [ "$TARGETARCH" = "$(go env GOHOSTARCH)" ]; then go test ./...; else echo "skip tests (cross-compile to $TARGETARCH)"; fi
 
-# build binaries
-RUN go build -ldflags="-X main.buildTimestamp=$(date '+%Y%m%d%H%M%S')" -o risk_demo_rule cmd/risk_demo/main.go
-RUN go build -ldflags="-X main.buildTimestamp=$(date '+%Y%m%d%H%M%S')" -o threagile cmd/threagile/main.go
+# build binaries for the target platform
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-X main.buildTimestamp=$(date '+%Y%m%d%H%M%S')" -o risk_demo_rule cmd/risk_demo/main.go
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-X main.buildTimestamp=$(date '+%Y%m%d%H%M%S')" -o threagile cmd/threagile/main.go
 
 # add the -race parameter to go build call in order to instrument with race condition detector: https://blog.golang.org/race-detector
 # NOTE: copy files with final name to send to final build

--- a/README.md
+++ b/README.md
@@ -30,6 +30,19 @@ The easiest way to execute Threagile on the commandline is via its Docker contai
     docker run --rm -it threagile/threagile --help
 ```
 
+Native multi-arch images (`linux/amd64` and `linux/arm64`, e.g. for Apple Silicon Macs) are
+also published to the GitHub Container Registry and run without emulation:
+
+```shell
+    docker run --rm -it ghcr.io/threagile/threagile --help
+```
+
+To build a multi-arch image locally:
+
+```shell
+    docker buildx build --platform linux/amd64,linux/arm64 -f Dockerfile.local -t threagile .
+```
+
 Which will give you an output with possible flags that can be used with Threagile.
 
 ```


### PR DESCRIPTION
## Problem

The published `threagile/threagile` image is **amd64-only**. On Apple Silicon (arm64) and other arm64 hosts it therefore runs under slow QEMU emulation, and no native arm64 image is available.

## Change

Make Threagile's Docker build cross-architecture capable and publish native multi-arch images:

- **`Dockerfile` and `Dockerfile.local`**: use BuildKit's automatic platform args (`BUILDPLATFORM`/`TARGETOS`/`TARGETARCH`), build the toolchain stage on the native platform and cross-compile the binaries via `GOOS`/`GOARCH`. `CGO_ENABLED=0` is now set — Threagile uses no cgo and no Go `plugin` package (custom risk rules are standalone executables invoked via `os/exec`, see `pkg/model/runner.go`), so the previous "CGO can't be disabled" note no longer applies. `go test ./...` runs only when building for the native arch (cross-compiled test binaries can't execute on the builder).
- **`.github/workflows/docker-publish.yml`** (new): builds `linux/amd64` + `linux/arm64` and pushes to **GHCR** (`ghcr.io/threagile/threagile`) using the built-in `GITHUB_TOKEN` — no additional repository secrets required. Pull requests build both architectures without pushing.
- **`README.md`**: document the GHCR multi-arch image and the local multi-arch build command.

The existing Docker Hub publishing path is unaffected; the cross-build changes also make it possible to produce arm64 images there.

## Verification

- Native build on arm64 (`podman build --platform linux/arm64 -f Dockerfile.local .`): succeeds, tests run, image runs.
- Cross-compile to amd64 on an arm64 host: succeeds quickly, tests are skipped as intended, the resulting amd64 image runs.

Closes the gap for arm64/Apple Silicon users.

## Note for maintainers

The first push to GHCR requires the repository's **Settings → Actions → General → Workflow permissions** to be set to **"Read and write permissions"** (the workflow only requests `packages: write` via `GITHUB_TOKEN`, so no new secrets are needed). On the initial run the `ghcr.io/threagile/threagile` package is created automatically; it should then be set to public under the package settings if anonymous `docker pull` is desired.
